### PR TITLE
Make KeywordCalls work for constructors

### DIFF
--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -44,10 +44,11 @@ function _kwcall(call)
             π = invperm(sortperm(collect(args)))
             sargs = Tuple(sort(args))
             targs = Tuple(args)
+            tf = to_type(f)
             quote
                 KeywordCalls.baseperm[($f, $sargs)] = $π
 
-                $f(nt::NamedTuple) = kwcall($f, nt)
+                $f(nt::NamedTuple) = kwcall($tf, nt)
 
                 $f(; kwargs...) = $f(kwargs.data)
 
@@ -63,8 +64,8 @@ end
 
 Dispatch to the permuted `f(::NamedTuple)` call declared using `@kwcall`
 """
-@gg function kwcall(::F, nt::NamedTuple{N}) where {F,N}
-    f = F.instance
+@gg function kwcall(::Type{TF}, nt::NamedTuple{N}) where {TF,N}
+    f = from_type(TF)
     π = Tuple(kwcallperm(f, N))
     Nπ = Tuple((N[p] for p in π))
     quote

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -44,11 +44,10 @@ function _kwcall(call)
             π = invperm(sortperm(collect(args)))
             sargs = Tuple(sort(args))
             targs = Tuple(args)
-            tf = to_type(f)
             quote
                 KeywordCalls.baseperm[($f, $sargs)] = $π
 
-                $f(nt::NamedTuple) = kwcall($tf, nt)
+                $f(nt::NamedTuple) = kwcall($f, nt)
 
                 $f(; kwargs...) = $f(kwargs.data)
 
@@ -64,8 +63,18 @@ end
 
 Dispatch to the permuted `f(::NamedTuple)` call declared using `@kwcall`
 """
-@gg function kwcall(::Type{TF}, nt::NamedTuple{N}) where {TF,N}
-    f = from_type(TF)
+@gg function kwcall(::Type{F}, nt::NamedTuple{N}) where {F,N}
+    π = Tuple(kwcallperm(F, N))
+    Nπ = Tuple((N[p] for p in π))
+    quote
+        v = values(nt)
+        valind(n) = @inbounds v[n]
+        $F(NamedTuple{$Nπ}(Tuple(valind.($π))))
+    end
+end
+
+@gg function kwcall(::F, nt::NamedTuple{N}) where {F<:Function,N}
+    f = F.instance
     π = Tuple(kwcallperm(f, N))
     Nπ = Tuple((N[p] for p in π))
     quote
@@ -74,6 +83,5 @@ Dispatch to the permuted `f(::NamedTuple)` call declared using `@kwcall`
         $f(NamedTuple{$Nπ}(Tuple(valind.($π))))
     end
 end
-
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,22 @@ using Test
 f(nt::NamedTuple{(:c,:b,:a)}) = nt.a^3 + nt.b^2 + nt.c
 @kwcall f(c,b,a)
 
+struct Foo{N,T}
+    nt::NamedTuple{N,T}
+end
+
+Foo(nt::NamedTuple{(:a,:b),T}) where {T} = Foo{(:a,:b), T}(nt)
+
+@kwcall Foo(a,b)
+
 @testset "KeywordCalls.jl" begin
-    # @test @inferred f(1, 2, 3) == 32
-    @test @inferred f(a=1, b=2, c=3) == 8
-    @test @inferred f((a=1, b=2, c=3)) == 8
+    @testset "Functions" begin
+        # @test @inferred f(1, 2, 3) == 32
+        @test @inferred f(a=1, b=2, c=3) == 8
+        @test @inferred f((a=1, b=2, c=3)) == 8
+    end
+
+    @testset "Constructors" begin
+        @test @inferred Foo((b=1,a=2)).nt == (a=2,b=1)
+    end
 end


### PR DESCRIPTION
```julia
julia> using KeywordCalls

julia> struct Foo{N,T}
           nt::NamedTuple{N,T}
       end

julia> Foo(nt::NamedTuple{(:a,:b),T}) where {T} = Foo{(:a,:b), T}(nt)
Foo

julia> @kwcall Foo(a,b)
Foo

julia> Foo((b=1,a=2))
Foo{(:a, :b), Tuple{Int64, Int64}}((a = 2, b = 1))
```