### PR TITLE
kwstruct macro

### DIFF
--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -23,14 +23,13 @@ function _kwcall(ex)
     @assert Meta.isexpr(ex, :call)
     f = ex.args[1]
     args = ex.args[2:end]
-    qargs = esc.(args)
     f, args, sorted_args = esc(f), QuoteNode.(args), QuoteNode.(sort(args))
     q = quote
         KeywordCalls._call_in_default_order(::typeof($f), nt::NamedTuple{($(sorted_args...),)}) = $f(NamedTuple{($(args...),)}(nt))
         $f(nt::NamedTuple) = KeywordCalls._call_in_default_order($f, _sort(nt))
         $f(; kw...) = $f(NamedTuple(kw))
     end
-    return (f=f, args=args, qargs=qargs, sorted_args=sorted_args, q=q)
+    return (f=f, args=args, sorted_args=sorted_args, q=q)
 end
 
 export @kwstruct 
@@ -50,8 +49,8 @@ Note that this assumes existence of a `Foo` struct of the form
 """
 macro kwstruct(ex)
     setup = _kwcall(ex)
-    (f, qargs, q) = setup.f, setup.qargs, setup.q
-    push!(q.args, :($f(nt::NamedTuple{($(qargs...),),T}) where {T} = $f{($(qargs...),), T}(nt)))
+    (f, args, q) = setup.f, setup.args, setup.q
+    push!(q.args, :($f(nt::NamedTuple{($(args...),),T}) where {T} = $f{($(args...),), T}(nt)))
 
     return q
 end

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -27,4 +27,11 @@ macro kwcall(ex)
     end
 end
 
+struct Foo{N,T} <: Bar
+    nt::NamedTuple{N,T}
+end
+
+
+Foo(nt::NamedTuple{(:μ,:σ),T}) where {T} = Foo{(:μ,:σ), T}(nt)
+
 end

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -10,28 +10,50 @@ function _call_in_default_order end
 
 # Thanks to @simeonschaub for this implementation 
 """
-@kwcall f(b,a,d)
+    @kwcall f(b,a,c)
 
-Declares that any call `f(::NamedTuple{N})` with `sort(N) == (:a,:b,:d)`
-should be dispatched to the method already defined on `f(::NamedTuple{(:b,:a,:d)})`
+Declares that any call `f(::NamedTuple{N})` with `sort(N) == (:a,:b,:c)`
+should be dispatched to the method already defined on `f(::NamedTuple{(:b,:a,:c)})`
 """
 macro kwcall(ex)
+    _kwcall(ex).q
+end
+
+function _kwcall(ex)
     @assert Meta.isexpr(ex, :call)
     f = ex.args[1]
     args = ex.args[2:end]
+    qargs = esc.(args)
     f, args, sorted_args = esc(f), QuoteNode.(args), QuoteNode.(sort(args))
-    return quote
+    q = quote
         KeywordCalls._call_in_default_order(::typeof($f), nt::NamedTuple{($(sorted_args...),)}) = $f(NamedTuple{($(args...),)}(nt))
         $f(nt::NamedTuple) = KeywordCalls._call_in_default_order($f, _sort(nt))
         $f(; kw...) = $f(NamedTuple(kw))
     end
+    return (f=f, args=args, qargs=qargs, sorted_args=sorted_args, q=q)
 end
 
-struct Foo{N,T} <: Bar
-    nt::NamedTuple{N,T}
+export @kwstruct 
+
+"""
+    @kwstruct Foo(b,a,c)
+
+Equivalent to `@kwcall Foo(b,a,c)` plus a definition
+
+    Foo(nt::NamedTuple{(:b, :a, :c), T}) where {T} = Foo{(:b, :a, :c), T}(nt)
+
+Note that this assumes existence of a `Foo` struct of the form
+
+    Foo{N,T} [<: SomeAbstractTypeIfYouLike]
+        someFieldName :: NamedTuple{N,T}
+    end
+"""
+macro kwstruct(ex)
+    setup = _kwcall(ex)
+    (f, qargs, q) = setup.f, setup.qargs, setup.q
+    push!(q.args, :($f(nt::NamedTuple{($(qargs...),),T}) where {T} = $f{($(qargs...),), T}(nt)))
+
+    return q
 end
-
-
-Foo(nt::NamedTuple{(:μ,:σ),T}) where {T} = Foo{(:μ,:σ), T}(nt)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,7 @@ struct Foo{N,T}
     nt::NamedTuple{N,T}
 end
 
-Foo(nt::NamedTuple{(:a,:b),T}) where {T} = Foo{(:a,:b), T}(nt)
-
-@kwcall Foo(a,b)
+@kwstruct Foo(a,b)
 
 @testset "KeywordCalls.jl" begin
     @testset "Functions" begin


### PR DESCRIPTION
"""
    @kwstruct Foo(b,a,c)

Equivalent to `@kwcall Foo(b,a,c)` plus a definition

    Foo(nt::NamedTuple{(:b, :a, :c), T}) where {T} = Foo{(:b, :a, :c), T}(nt)

Note that this assumes existence of a `Foo` struct of the form

    Foo{N,T} [<: SomeAbstractTypeIfYouLike]
        someFieldName :: NamedTuple{N,T}
    end
"""