### PR TITLE
Default Value Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ f(nt::NamedTuple{(:c, :a, :b)}) = println("The sum is ", sum(values(nt)))
 then
 
 ```julia
-julia> f(a=1, b=2)
+julia> f(a=1,b=2)
 The sum is 3
 
 julia> f(a=1,b=2,c=3)

--- a/README.md
+++ b/README.md
@@ -29,17 +29,20 @@ julia> f(b=2,a=1)
 Calling f(b = 2,a = 1)
 ```
 
-We can define a new method for any set of arguments we like. If (after the above) we also define
+We can define a new method for any set of arguments we like, including default values. If (after the above) we also define
 
 ```julia
 f(nt::NamedTuple{(:c, :a, :b)}) = println("The sum is ", sum(values(nt)))
 
-@kwcall f(c,a,b)
+@kwcall f(c=0,a,b)
 ```
 
 then
 
 ```julia
+julia> f(a=1, b=2)
+The sum is 3
+
 julia> f(a=1,b=2,c=3)
 The sum is 6
 ```
@@ -56,7 +59,7 @@ end
 then
 
 ```julia
-julia> @kwstruct Foo(μ,σ)
+julia> @kwstruct Foo(μ,σ=1)
 Foo
 
 julia> Foo(σ=2,μ=4)

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -10,7 +10,7 @@ function _call_in_default_order end
 
 # Thanks to @simeonschaub for this implementation 
 """
-    @kwcall f(b,a,c)
+    @kwcall f(b,a,c=0)
 
 Declares that any call `f(::NamedTuple{N})` with `sort(N) == (:a,:b,:c)`
 should be dispatched to the method already defined on `f(::NamedTuple{(:b,:a,:c)})`
@@ -46,9 +46,9 @@ _get_arg(s::Symbol) = s
 export @kwstruct 
 
 """
-    @kwstruct Foo(b,a,c)
+    @kwstruct Foo(b,a,c=0)
 
-Equivalent to `@kwcall Foo(b,a,c)` plus a definition
+Equivalent to `@kwcall Foo(b,a,c=0)` plus a definition
 
     Foo(nt::NamedTuple{(:b, :a, :c), T}) where {T} = Foo{(:b, :a, :c), T}(nt)
 

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -26,8 +26,8 @@ function _kwcall(ex)
     f, args, sorted_args = esc(f), QuoteNode.(args), QuoteNode.(sort(args))
     q = quote
         KeywordCalls._call_in_default_order(::typeof($f), nt::NamedTuple{($(sorted_args...),)}) = $f(NamedTuple{($(args...),)}(nt))
-        $f(nt::NamedTuple) = KeywordCalls._call_in_default_order($f, _sort(merge((;$(defaults...)), nt)))
-        $f(; kw...) = $f(merge((;$(defaults...)), NamedTuple(kw)))
+        $f(nt::NamedTuple) = KeywordCalls._call_in_default_order($f, _sort(merge($defaults, nt)))
+        $f(; kw...) = $f(merge($defaults, NamedTuple(kw)))
     end
     return (f=f, args=args, sorted_args=sorted_args, q=q)
 end
@@ -35,8 +35,8 @@ end
 function _parse_args(args)
     # get args dropping the tail of any expressions
     _args = map(_get_arg, args)
-    # get the `key = val` defaults
-    _defaults = filter(a -> a isa Expr, args)
+    # get the `key = val` defaults as a NamedTuple
+    _defaults = @eval (;$(filter(a -> a isa Expr, args)...))
     return _args, _defaults
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,20 @@ using Test, Pkg
 f(nt::NamedTuple{(:c,:b,:a)}) = nt.a^3 + nt.b^2 + nt.c
 @kwcall f(c,b,a)
 
+g(nt::NamedTuple{(:c,:b,:a)}) = f(nt)
+@kwcall g(c=0, b, a)
+
 struct Foo{N,T}
     nt::NamedTuple{N,T}
 end
 
 @kwstruct Foo(a,b)
+
+struct Bar{N,T}
+    nt::NamedTuple{N,T}
+end
+
+@kwstruct Bar(a,b,c=0)
 
 @testset "KeywordCalls.jl" begin
     @testset "Functions" begin
@@ -22,13 +31,15 @@ end
     end
 
     @testset "Functions with defaults" begin
-        g(nt::NamedTuple{(:c,:b,:a)}) = f(nt)
-        @kwcall g(c=0, b, a)
-
         @test @inferred g(a=1, b=2) == 5
         @test @inferred g((a=1, b=2)) == 5
         @test @inferred g(a=1, b=2, c=3) == 8
         @test @inferred g((a=1, b=2, c=3)) == 8
+    end
+
+    @testset "Constructors with defaults" begin
+        @test @inferred Bar((b=1,a=2)).nt == (a=2,b=1,c=0)
+        @test @inferred Bar((b=1,a=2,c=5)).nt == (a=2,b=1,c=5)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,16 @@ end
     @testset "Constructors" begin
         @test @inferred Foo((b=1,a=2)).nt == (a=2,b=1)
     end
+
+    @testset "Functions with defaults" begin
+        g(nt::NamedTuple{(:c,:b,:a)}) = f(nt)
+        @kwcall g(c=0, b, a)
+
+        @test @inferred g(a=1, b=2) == 5
+        @test @inferred g((a=1, b=2)) == 5
+        @test @inferred g(a=1, b=2, c=3) == 8
+        @test @inferred g((a=1, b=2, c=3)) == 8
+    end
 end
 
 if isfile("./Precompile2/Manifest.toml")


### PR DESCRIPTION
Adds support for default values to `@kwcall`. The idea is that any default values get collected into a named tuple which gets `merge` with the named tuple generated by the `f(; kw...)` call. 

Usage-
```julia
f(nt::NamedTuple{(:a, :b, :c)}) = nt.a^3 + nt.b^2 + nt.c
@kwcall f(a, b, c=0)

f(a=1, b=2) == 5
f(a=1, b=2, c=3) == 8
```

In terms of the implementation, I'm not sure how clunky it is (I'm not the best at metaprogramming) so any advice there would be great. I originally wanted the second output from `_parse_args` to be the default values *already collected into a named tuple* but I didn't know how to do that so I just threw it inside the quote returned by `_kwcall`.
