### PR TITLE
const inst = $instance_type($f) in macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeywordCalls"
 uuid = "4d827475-d3e4-43d6-abe3-9688362ede9f"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -52,7 +52,9 @@ function _kwcall(__module__, ex)
     _sort = KeywordCalls._sort
     instance_type = KeywordCalls.instance_type
     q = quote
-        function KeywordCalls._call_in_default_order(::$instance_type($f), nt::NamedTuple{($(sorted_argnames...),)})
+        const inst = $instance_type($f)
+
+        function KeywordCalls._call_in_default_order(::inst, nt::NamedTuple{($(sorted_argnames...),)})
             return $f_esc(NamedTuple{($(argnames...),)}(nt))
         end
     end
@@ -146,7 +148,13 @@ function _kwalias(f, aliasmap)
         @assert pair.head == :call
         @assert pair.args[1] == :(=>)
         (a,b) = QuoteNode.(pair.args[2:3])
-        push!(q.args, :(KeywordCalls.alias(::$instance_type($f), ::Val{$a}) = $b))
+
+        newmethod = quote
+            const inst = $instance_type($f)
+            KeywordCalls.alias(::inst, ::Val{$a}) = $b
+        end
+
+        push!(q.args, newmethod)
     end
     return q
 end


### PR DESCRIPTION
I was seeing some strange behavior in MeasureTheory, and I think it was coming from macros containing functions defined on
```julia
::$instance_type($f)
```

This PR changes that. First we define
```julia
const inst = $instance_type($f)
```
then the argument can just be
```julia
::inst
```

We can use the same `inst` in each case, because macro hygiene will force this to be implemented as a different name each time.