### PR TITLE
bugfix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeywordCalls"
 uuid = "4d827475-d3e4-43d6-abe3-9688362ede9f"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -56,8 +56,6 @@ function _kwcall(__module__, ex)
     
     inst = instance_type(f)
     q = quote
-        # const $inst = $instance_type($f)
-
         function KeywordCalls._call_in_default_order(::$inst, nt::NamedTuple{($(sorted_argnames...),)})
             return $f_esc(NamedTuple{($(argnames...),)}(nt))
         end
@@ -133,11 +131,11 @@ function _kwstruct(__module__, ex)
     # of the `build` method and know whether the constructor method is defined.
     if !static_hasmethod(build, Tuple{instance_type(f), Tuple{NamedTuple{((args...),)}}})
         argnames = QuoteNode.(args)
-        
+
+        inst = instance_type(f)
         new_method = quote
-            const inst = $instance_type($f_esc)
             $f_esc(nt::NamedTuple{($(argnames...),),T}) where {T} = $f_esc{($(argnames...),), T}(nt)
-            KeywordCalls.build(::inst, ::NamedTuple{($(argnames...),),T}) where {T} = true
+            KeywordCalls.build(::$inst, ::NamedTuple{($(argnames...),),T}) where {T} = true
         end
 
         push!(q.args, new_method)
@@ -159,11 +157,12 @@ declare that for the function `f`, we should consider `alpha` to be an alias for
 accordingly as a pre-processing step.
 """
 macro kwalias(f, aliasmap)
-    _kwalias(f, aliasmap)
+    _kwalias(__module__, f, aliasmap)
 end
 
-function _kwalias(f, aliasmap)
-    f = esc(f)
+function _kwalias(__module__, fsym, aliasmap)
+    f_esc = esc(fsym)
+    f = getproperty(__module__, fsym)
     q = quote end
     for pair in aliasmap.args
         # Each entry should look like `:(a => b)`
@@ -171,9 +170,9 @@ function _kwalias(f, aliasmap)
         @assert pair.args[1] == :(=>)
         (a,b) = QuoteNode.(pair.args[2:3])
 
-        @gensym inst
+        
+        inst = instance_type(f)
         newmethod = quote
-            const $inst = $instance_type($f)
             KeywordCalls.alias(::$inst, ::Val{$a}) = $b
         end
 

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -54,16 +54,14 @@ function _kwcall(__module__, ex)
     _sort = KeywordCalls._sort
     instance_type = KeywordCalls.instance_type
     
-
+    inst = instance_type(f)
     q = quote
-        const inst = $instance_type($f)
+        # const $inst = $instance_type($f)
 
-        function KeywordCalls._call_in_default_order(::inst, nt::NamedTuple{($(sorted_argnames...),)})
+        function KeywordCalls._call_in_default_order(::$inst, nt::NamedTuple{($(sorted_argnames...),)})
             return $f_esc(NamedTuple{($(argnames...),)}(nt))
         end
     end
-
-    inst = instance_type(f)
 
     if !static_hasmethod(has_kwargs, Tuple{inst})
         namedtuplemethod = quote
@@ -79,7 +77,7 @@ function _kwcall(__module__, ex)
 
         kwmethod = quote
             $f_esc(;kw...) = $f_esc(NamedTuple(kw))
-            KeywordCalls.has_kwargs(::inst) = true
+            KeywordCalls.has_kwargs(::$inst) = true
         end
 
         push!(q.args, kwmethod)


### PR DESCRIPTION
In interactive use, I sometimes get errors like

```julia
┌ Error: Failed to revise /home/chad/tmp/MeasureTheory.jl/src/parameterized/studentt.jl
│   exception =
│    invalid redefinition of constant #42#inst
│    Stacktrace:
│     [1] top-level scope
│       @ ~/.julia/packages/KeywordCalls/dIiYn/src/KeywordCalls.jl:59
│    Revise evaluation error at /home/chad/.julia/packages/KeywordCalls/dIiYn/src/KeywordCalls.jl:59
```

The problem seems to be that the macro name-mangling is simple enough that sometimes symbols get repeated.

This PR gets away from this approach, in this case replacing
```julia
    q = quote
        const inst = $instance_type($f)
        function KeywordCalls._call_in_default_order(::inst, nt::NamedTuple{($(sorted_argnames...),)})
        return $f_esc(NamedTuple{($(argnames...),)}(nt))
        end
    end
```
with
```julia
    inst = instance_type(f)
    q = quote
        function KeywordCalls._call_in_default_order(::$inst, nt::NamedTuple{($(sorted_argnames...),)})
            return $f_esc(NamedTuple{($(argnames...),)}(nt))
        end
    end
```