### PR TITLE
NamedTuple Specialization

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.4'
-          - '1.5'
           - '1.6'
+          - '1.7'
+          - '1.8'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [compat]
-Compat = "3.28"
+Compat = "3.28, 4"
 Tricks = "0.1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeywordCalls"
 uuid = "4d827475-d3e4-43d6-abe3-9688362ede9f"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -66,7 +66,7 @@ function _kwcall(__module__, __source__, ex)
             $__source__
             @inline function $f_esc(nt::NamedTuple{N,T}) where {N,T}
                 aliased = $alias($f, nt)
-                merged = merge($defaults, aliased)
+                merged = mymerge($defaults, aliased)
                 sorted = $_sort(merged)
                 return $_call_in_default_order($f, sorted)
             end

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -7,12 +7,12 @@ export @kwcall
 
 @generated _sort(nt::NamedTuple{K,T}) where {K,T} = :(NamedTuple{($(QuoteNode.(sort(collect(K)))...),)}(nt))
 
-@inline alias(f,::Val{k}) where {k} = k
+@inline alias(f,::Type{Val{k}}) where {k} = k
 
 alias(f, tup::Tuple) = alias.(f, tup)
 
 function alias(f, nt::NamedTuple{K,T}) where {K,T} 
-    newnames = alias(f, Val.(K))
+    newnames = tuple((alias(f, Val{k}) for k in K)...) 
     NamedTuple{newnames}(values(nt))
 end
 
@@ -177,7 +177,7 @@ function _kwalias(__module__, __source__, fsym, aliasmap)
         inst = Core.Typeof(f)
         newmethod = quote
             $__source__
-            KeywordCalls.alias(::$inst, ::Val{$a}) = $b
+            KeywordCalls.alias(::$inst, ::Type{Val{$a}}) = $b
         end
 
         push!(q.args, newmethod)

--- a/src/KeywordCalls.jl
+++ b/src/KeywordCalls.jl
@@ -64,7 +64,7 @@ function _kwcall(__module__, __source__, ex)
     if !static_hasmethod(has_kwargs, Tuple{inst})
         namedtuplemethod = quote
             $__source__
-            @inline function $f_esc(nt::NamedTuple{N,T}) where {N,T}
+            @inline function $f_esc(nt::NamedTuple)
                 aliased = $alias($f, nt)
                 merged = mymerge($defaults, aliased)
                 sorted = $_sort(merged)


### PR DESCRIPTION
@Seelengrab reminded me of this:
https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing

so methods referring to `NamedTuple{N}` instead of `NamedTuple{N,T}` will not be specialized for the input types.

At least for MeasureTheory, the number of possible types for a given `NamedTuple{N}` is usually pretty small, but specialization can be important. This PR makes this methods more specialized.

A potential downside is that this can increase the size of the method table. But as I understand, that should only become much of an issue when calling with lots of variations of types. At least for my purposes (in MeasureTheory, etc), I don't think this will become an issue.

@Seelengrab also pointed out that it can be hard to track down where a macro has been called. I've added some `LineNumberNodes` to try to improve this.